### PR TITLE
Status for single dependency

### DIFF
--- a/src/main/net/polydawn/mdm/MdmArgumentParser.java
+++ b/src/main/net/polydawn/mdm/MdmArgumentParser.java
@@ -63,6 +63,9 @@ public class MdmArgumentParser {
 		Subparser parser_status = subparsers
 			.addParser("status")
 			.help("list dependencies managed by mdm, and their current status.");
+		parser_status
+			.addArgument("--name")
+			.help("get the status of a particular dependency by name");
 
 
 		Subparser parser_update = subparsers


### PR DESCRIPTION
Added a flag to status that takes dependency name and returns only that dependency's version.  That way, if you wanted say, an ant exec to get the version of a particular release and write it out to a human readable file that persists in a build, you don't have to regex the results.