### PR TITLE
status selectors

### DIFF
--- a/src/main/net/polydawn/mdm/MdmArgumentParser.java
+++ b/src/main/net/polydawn/mdm/MdmArgumentParser.java
@@ -63,6 +63,9 @@ public class MdmArgumentParser {
 		Subparser parser_status = subparsers
 			.addParser("status")
 			.help("list dependencies managed by mdm, and their current status.");
+		parser_status
+			.addArgument("--name")
+			.help("get the status of a particular dependency by name");
 
 
 		Subparser parser_update = subparsers

--- a/src/main/net/polydawn/mdm/MdmArgumentParser.java
+++ b/src/main/net/polydawn/mdm/MdmArgumentParser.java
@@ -69,6 +69,7 @@ public class MdmArgumentParser {
 		parser_status
 			.addArgument("--format")
 			.help("the format of report to print.  Some formats contain subsets of information, suitable for use in extracting values for other scripts.  Valid values include: default, versionCheckedOut, versionSpecified.");
+			// more valid values may come in the future.  also arbitrary format strings could be introduced by following the example set by `git log --format`.
 
 
 		Subparser parser_update = subparsers

--- a/src/main/net/polydawn/mdm/MdmArgumentParser.java
+++ b/src/main/net/polydawn/mdm/MdmArgumentParser.java
@@ -65,7 +65,10 @@ public class MdmArgumentParser {
 			.help("list dependencies managed by mdm, and their current status.");
 		parser_status
 			.addArgument("--name")
-			.help("get the status of a particular dependency by name");
+			.help("get the status of a particular dependency by name.  If specified, only that dependency will be included in the report.");
+		parser_status
+			.addArgument("--format")
+			.help("the format of report to print.  Some formats contain subsets of information, suitable for use in extracting values for other scripts.  Valid values include: default, versionCheckedOut, versionSpecified.");
 
 
 		Subparser parser_update = subparsers

--- a/src/main/net/polydawn/mdm/MdmModule.java
+++ b/src/main/net/polydawn/mdm/MdmModule.java
@@ -85,7 +85,7 @@ public abstract class MdmModule {
 			// sanity check the expected module type if we're a submodule (if we're not a submodule, we can't make any such check since there's no gitmodules file to refer to).
 			MdmModuleType type = getType();
 			MdmModuleType type_configured = MdmModuleType.fromString(gitmodulesCfg.getString(ConfigConstants.CONFIG_SUBMODULE_SECTION, handle, MdmConfigConstants.Module.MODULE_TYPE.toString()));
-			if (type == null)
+			if (type_configured == null)
 				throw new MdmModuleTypeException("expected module of type " + type + " for repository " + handle + ", but gitmodules file has no known type for this module.");
 			if (type != type_configured)
 				throw new MdmModuleTypeException("expected module of type " + type + " for repository " + handle + ", but gitmodules file states this is a " + type_configured + " module.");

--- a/src/main/net/polydawn/mdm/commands/MdmStatusCommand.java
+++ b/src/main/net/polydawn/mdm/commands/MdmStatusCommand.java
@@ -26,6 +26,8 @@ import net.polydawn.mdm.errors.*;
 import net.sourceforge.argparse4j.inf.*;
 import org.eclipse.jgit.errors.*;
 import org.eclipse.jgit.lib.*;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
+
 import us.exultant.ahs.util.*;
 
 public class MdmStatusCommand extends MdmCommand {
@@ -37,7 +39,11 @@ public class MdmStatusCommand extends MdmCommand {
 		super(repo);
 	}
 
-	public void parse(Namespace args) {}
+	private String depName;
+
+	public void parse(Namespace args) {
+		this.depName = args.getString("name");
+	}
 
 	public void validate() throws MdmExitMessage {}
 
@@ -46,6 +52,17 @@ public class MdmStatusCommand extends MdmCommand {
 			assertInRepo();
 		} catch (MdmExitMessage e) {
 			return e;
+		}
+
+		if (depName != null) {
+			StoredConfig gitmodulesCfg = new FileBasedConfig(new File(repo.getWorkTree(), Constants.DOT_GIT_MODULES), repo.getFS());
+			try {
+				gitmodulesCfg.load();
+			} catch (ConfigInvalidException e) {
+				throw new MdmExitInvalidConfig(Constants.DOT_GIT_MODULES);
+			}
+			os.printf(MdmModuleDependency.load(repo, depName, gitmodulesCfg).getVersionActual());
+			return new MdmExitMessage(0);
 		}
 
 		MdmModuleSet moduleSet;

--- a/src/main/net/polydawn/mdm/commands/MdmStatusCommand.java
+++ b/src/main/net/polydawn/mdm/commands/MdmStatusCommand.java
@@ -40,12 +40,31 @@ public class MdmStatusCommand extends MdmCommand {
 	}
 
 	private String depName;
+	private String formatName;
 
 	public void parse(Namespace args) {
 		this.depName = args.getString("name");
+		this.formatName = args.getString("format");
 	}
 
-	public void validate() throws MdmExitMessage {}
+	private Formatter formatter;
+
+	private static Map<String,Formatter> formatters = new HashMap<String,Formatter>() {{
+		put("default", new FormatDefault());
+		put("versionCheckedOut", new FormatVersionCheckedOut());
+		put("versionSpecified", new FormatVersionSpecified());
+	}};
+
+	public void validate() throws MdmExitMessage {
+		if (this.formatName == null) {
+			this.formatter = new FormatDefault();
+		} else {
+			this.formatter = formatters.get(formatName);
+			if (this.formatter == null) {
+				throw new MdmExitMessage(":(", "invalid argument: no formatter of name \""+this.formatName+"\"");
+			}
+		}
+	}
 
 	public MdmExitMessage call() throws IOException {
 		try {
@@ -55,46 +74,35 @@ public class MdmStatusCommand extends MdmCommand {
 		}
 
 		if (depName != null) {
+			// if a specific dep name was specified, just load that one individually
 			StoredConfig gitmodulesCfg = new FileBasedConfig(new File(repo.getWorkTree(), Constants.DOT_GIT_MODULES), repo.getFS());
 			try {
 				gitmodulesCfg.load();
 			} catch (ConfigInvalidException e) {
 				throw new MdmExitInvalidConfig(Constants.DOT_GIT_MODULES);
 			}
-			os.printf(MdmModuleDependency.load(repo, depName, gitmodulesCfg).getVersionActual());
+
+			MdmModuleDependency module = MdmModuleDependency.load(repo, depName, gitmodulesCfg);
+			this.formatter.fprintf(os, Arrays.asList(module));
+
+			return new MdmExitMessage(0);
+		} else {
+			// scan all modules and do a report on all of them
+			MdmModuleSet moduleSet;
+			try {
+				moduleSet = new MdmModuleSet(repo);
+			} catch (ConfigInvalidException e) {
+				throw new MdmExitInvalidConfig(Constants.DOT_GIT_MODULES);
+			}
+			Map<String,MdmModuleDependency> modules = moduleSet.getDependencyModules();
+
+			this.formatter.fprintf(os, modules.values());
+
 			return new MdmExitMessage(0);
 		}
-
-		MdmModuleSet moduleSet;
-		try {
-			moduleSet = new MdmModuleSet(repo);
-		} catch (ConfigInvalidException e) {
-			throw new MdmExitInvalidConfig(Constants.DOT_GIT_MODULES);
-		}
-		Map<String,MdmModuleDependency> modules = moduleSet.getDependencyModules();
-
-		if (modules.size() == 0) {
-			os.println(" --- no managed dependencies --- ");
-			return new MdmExitMessage(0);
-		}
-
-		Collection<String> row1 = new ArrayList<String>(modules.keySet());
-		row1.add("dependency:");
-		int width1 = Strings.chooseFieldWidth(row1);
-
-		os.printf("%-"+width1+"s   \t %s\n", "dependency:", "version:");
-		os.printf("%-"+width1+"s   \t %s\n", "-----------", "--------");
-
-		for (MdmModuleDependency mod : modules.values()) {
-			StatusTuple status = status(mod);
-			os.printf("  %-"+width1+"s \t   %s\n", mod.getHandle(), status.version);
-			for (String warning : status.warnings)
-				os.printf("  %-"+width1+"s \t   %s\n", "", "  !! "+warning);
-		}
-		return new MdmExitMessage(0);
 	}
 
-	public StatusTuple status(MdmModule module) {
+	private static StatusTuple status(MdmModule module) {
 		StatusTuple s = new StatusTuple();
 
 		if (!module.getHandle().equals(module.getPath()))
@@ -125,7 +133,7 @@ public class MdmStatusCommand extends MdmCommand {
 
 
 
-	public class StatusTuple {
+	public static class StatusTuple {
 		public String version;
 		/**
 		 * Major notifications about the state of a module -- things that mean
@@ -137,5 +145,59 @@ public class MdmStatusCommand extends MdmCommand {
 		 * with this module.
 		 */
 		public List<String> errors = new ArrayList<String>();
+	}
+
+
+
+	interface Formatter {
+		public void fprintf(PrintStream f, Collection<MdmModuleDependency> modules);
+	}
+
+
+
+	private static class FormatDefault implements Formatter {
+		public void fprintf(PrintStream f, Collection<MdmModuleDependency> modules) {
+			if (modules.size() == 0) {
+				f.println(" --- no managed dependencies --- ");
+				return;
+			}
+
+			Collection<String> row1 = new ArrayList<String>(modules.size()+1);
+			row1.add("dependency:");
+			for (MdmModuleDependency mod : modules) {
+				row1.add(mod.getHandle());
+			}
+			int width1 = Strings.chooseFieldWidth(row1);
+
+			f.printf("%-" + width1 + "s   \t %s\n", "dependency:", "version:");
+			f.printf("%-" + width1 + "s   \t %s\n", "-----------", "--------");
+
+			for (MdmModuleDependency mod : modules) {
+				StatusTuple status = status(mod);
+				f.printf("  %-" + width1 + "s \t   %s\n", mod.getHandle(), status.version);
+				for (String warning : status.warnings)
+					f.printf("  %-" + width1 + "s \t   %s\n", "", "  !! " + warning);
+			}
+		}
+	}
+
+
+
+	private static class FormatVersionCheckedOut implements Formatter {
+		public void fprintf(PrintStream f, Collection<MdmModuleDependency> modules) {
+			for (MdmModuleDependency mod : modules) {
+				f.println(mod.getVersionActual());
+			}
+		}
+	}
+
+
+
+	private static class FormatVersionSpecified implements Formatter {
+		public void fprintf(PrintStream f, Collection<MdmModuleDependency> modules) {
+			for (MdmModuleDependency mod : modules) {
+				f.println(mod.getVersionName());
+			}
+		}
 	}
 }

--- a/src/main/net/polydawn/mdm/commands/MdmStatusCommand.java
+++ b/src/main/net/polydawn/mdm/commands/MdmStatusCommand.java
@@ -39,8 +39,8 @@ public class MdmStatusCommand extends MdmCommand {
 		super(repo);
 	}
 
-	private String depName;
-	private String formatName;
+	String depName;
+	String formatName;
 
 	public void parse(Namespace args) {
 		this.depName = args.getString("name");
@@ -82,8 +82,12 @@ public class MdmStatusCommand extends MdmCommand {
 				throw new MdmExitInvalidConfig(Constants.DOT_GIT_MODULES);
 			}
 
-			MdmModuleDependency module = MdmModuleDependency.load(repo, depName, gitmodulesCfg);
-			this.formatter.fprintf(os, Arrays.asList(module));
+			try {
+				MdmModuleDependency module = MdmModuleDependency.load(repo, depName, gitmodulesCfg);
+				this.formatter.fprintf(os, Arrays.asList(module));
+			} catch (MdmModuleTypeException e) {
+				this.formatter.fprintf(os, Collections.EMPTY_LIST);
+			}
 
 			return new MdmExitMessage(0);
 		} else {

--- a/src/test-integration/net/polydawn/mdm/commands/MdmStatusCommandTest.java
+++ b/src/test-integration/net/polydawn/mdm/commands/MdmStatusCommandTest.java
@@ -121,6 +121,61 @@ public class MdmStatusCommandTest extends TestCaseUsingRepository {
 		}
 		wd.close();
 	}
+
+	@Test
+	public void testDescribeNamedDep() throws Exception {
+		Fixture project = new ProjectDelta("projectRepo");
+
+		WithCwd wd = new WithCwd(project.getRepo().getWorkTree());
+		{
+			PrintGatherer pg = new PrintGatherer();
+			MdmStatusCommand cmd = new MdmStatusCommand(project.getRepo(), pg.printer());
+			cmd.depName = "lib/alpha";
+			cmd.validate();
+			assertJoy(cmd.call());
+			assertEquals(Strings.join(Arrays.asList(
+				"dependency:        	 version:",
+				"-----------        	 --------",
+				"  lib/alpha        	   v1"
+				// there's another here, but in this mode it goes unreported.
+				), "\n") + "\n",
+				pg.toString());
+		}
+		wd.close();
+	}
+
+	@Test
+	public void testDescribeNamedDepNotThere() throws Exception {
+		Fixture project = new ProjectAlpha("projectRepo");
+
+		WithCwd wd = new WithCwd(project.getRepo().getWorkTree());
+		{
+			PrintGatherer pg = new PrintGatherer();
+			MdmStatusCommand cmd = new MdmStatusCommand(project.getRepo(), pg.printer());
+			cmd.depName = "lib/alpha";
+			cmd.validate();
+			assertJoy(cmd.call()); // REVIEW: maybe this should actually be an error?
+			assertEquals(" --- no managed dependencies --- \n", pg.toString());
+		}
+		wd.close();
+	}
+
+	@Test
+	public void testDescribeNamedDepWithShortFormate() throws Exception {
+		Fixture project = new ProjectDelta("projectRepo");
+
+		WithCwd wd = new WithCwd(project.getRepo().getWorkTree());
+		{
+			PrintGatherer pg = new PrintGatherer();
+			MdmStatusCommand cmd = new MdmStatusCommand(project.getRepo(), pg.printer());
+			cmd.depName = "lib/alpha";
+			cmd.formatName = "versionCheckedOut";
+			cmd.validate();
+			assertJoy(cmd.call());
+			assertEquals("v1\n", pg.toString());
+		}
+		wd.close();
+	}
 }
 
 


### PR DESCRIPTION
- Added a flag to `mdm status` that takes dependency name and returns only that dependency's information.
- Added a flag to `mdm status` that allows specifying a report format style (short, single-value formats can be useful for scripting).

(I took #10 and ran with it!  Same commit at the bottom, though with a different hash because I backpedaled to add a ton of testing stuff to master and then restacked this on top of it.)

