### PR TITLE
Alexives/update jgit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build/
 dist/
-demo/
+mdm-demo/
 target/
 build.properties
 *krap*

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,7 +28,7 @@
 	path = lib/jgit
 	url = http://mdm-releases.com/org.eclipse.jgit/org.eclipse.jgit-releases.git
 	mdm = dependency
-	mdm-version = 3.3.2.201404171909-r.mvn
+	mdm-version = 4.0.0.201505050340-m2.mvn
 	update = none
 [submodule "lib/jsch"]
 	path = lib/jsch

--- a/build.xml
+++ b/build.xml
@@ -53,6 +53,7 @@
 		<pathelement location="${lib}/argparse4j/argparse4j.jar"/>
 		<pathelement location="${lib}/jsch/jsch.jar"/>
 		<pathelement location="${lib}/commons-lang/commons-lang.jar"/>
+		<pathelement location="${lib}/slf4j/slf4j-api.jar"/>
 	</path>
 	<path id="mdm.path.main">
 		<path refid="mdm.path.deps.main" />
@@ -93,14 +94,17 @@
 			<zipfileset src="${lib}/argparse4j/argparse4j.jar" includes="**/*.class"/>
 			<zipfileset src="${lib}/jsch/jsch.jar" includes="**/*.class"/>
 			<zipfileset src="${lib}/commons-lang/commons-lang.jar" includes="**/*.class"/>
+			<zipfileset src="${lib}/slf4j/slf4j-api.jar" includes="**/*.class"/>
 		</exusPack>
 		<chmod file="${dist}/${app}" perm="755"/>
 	</target>
 
-
-	<!-- Mac doesn't put things in the standard location -->
-	<condition property="mdm.java.lib.path" value="${java.home}/../Classes/classes.jar" else="${java.home}/lib/rt.jar">
-		<os family="mac" />
+	<!-- Mac doesn't put things in the standard location for java 1.6, java 1.7 and later are normal -->
+	<condition property="mdm.java.lib.path" value="${java.home}../Classes/classes.jar" else="${java.home}/lib/rt.jar">
+		<and>
+			<equals arg1="${ant.java.version}" arg2="1.6"/>
+			<os family="mac" />
+		</and>
 	</condition>
 
 	<target name="dist-packed" depends="dist"


### PR DESCRIPTION
I've been encountering issues with jgit being very flaky on certain operations involving large dependencies (~500mb) where an mdm release operation can take 1-2 hours, and I think updating jgit might help. I've also fixed an issue with building on os x due to asset locations in the Apple provided 1.6 jre that changed in the now oracle provided 1.7 jre.

@heavenlyhash, I'd really like to bump jgit all the way to latest while I'm at it, but the mdm-releases only has up to 4.0.0, is that something you can help with? Also, It'd be great if you could double check I didn't screw something up when building for other platforms. Was there a reason log4j wasn't in the uber jar before? I couldn't run tests or the final executable until after I added it. 

Should I rebase this off of stable and try again? The guid for contributing says I should branch from master...

After these fixes both run-tests and run-mdma report success, however I get:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

when I run the mdm executable in target/dist.
